### PR TITLE
fix: Docker compose supports the arm64 architecture of Mac M1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,7 @@ services:
       - kafka
     restart: always
   mysql:
-    image: mysql:5.7.24
+    image: mysql:5.7.37
     networks:
       - mogo-net
     environment:


### PR DESCRIPTION
Mac M1下无法运行docker mysql 5.7.24镜像